### PR TITLE
Fix bug with absolute file paths

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -14,7 +14,7 @@ module.exports = function load_environment_variables_from_file (filepath) {
     var parent_directory = module_callee.slice(0,called_by_module);
     if(filepath) { // if required without a config.env file we search for one!
       if(called_by_module > -1){
-        filepath = path.resolve(parent_directory + filepath);
+        filepath = path.resolve(parent_directory, filepath);
       }
       else {
         filepath = path.resolve(filepath);

--- a/test/node_modules/callee.test.js
+++ b/test/node_modules/callee.test.js
@@ -4,10 +4,11 @@ var path    = require('path');
 decache('../lib/env.js');    // delete any previously cached version
 decache('../../lib/env.js'); // delete alias from require cache
 var config  = path.resolve(__dirname + '/../config.env');
-require('../../lib/env.js')(config); // local
 
 // this ensures that the node_modules condition in lib/env.js is met
 test("Confirm that EVERYTHING=AWESOME", function(t) {
+  delete process.env.EVERYTHING;
+  require('../../lib/env.js')(config); // local
   t.ok(process.env.EVERYTHING === 'AWESOME',
   'Worked! Everything is: '+process.env.EVERYTHING)
 


### PR DESCRIPTION
Because `path.resolve` was being misused by passing a concatenated string directly rather than a series of path arguments, then passing an absolute path into the `env` function would not find the file in cases where it was loaded relative to a parent directory (it concatenated the path to itself).

This should have manifested in a failing test, but the test itself was flawed so that it used an environment variable left over by a previous test. Resolve that issue by explicitly removing the particular environment variable under test at the beginning of the test.