### PR TITLE
We always refer to env.json rather than config.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ below** for placing it in your `.gitignore` file.
 
 ### *Alternatively* Create an `env.json` Configuration File
 
-If you *prefer* to use `.json` instead of `.env` create a `config.json` file in your repo with the following format:
+If you *prefer* to use `.json` instead of `.env` create a `env.json` file in your repo with the following format:
 
 ```js
 {


### PR DESCRIPTION
I think that referring to `config.json` was a typo that confused me a bit. The name is not important, but being consistent I think that helps readability.